### PR TITLE
Server connection and sending video

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -8,6 +8,7 @@
         Apache Cordova Team
     </author>
     <content src="index.html" />
+    <preference name="AndroidPersistentFileLocation" value="Compatibility" />
     <plugin name="cordova-plugin-whitelist" spec="1" />
     <access origin="*" />
     <allow-intent href="http://*/*" />
@@ -16,6 +17,7 @@
     <allow-intent href="sms:*" />
     <allow-intent href="mailto:*" />
     <allow-intent href="geo:*" />
+    <preference name="loadUrlTimeoutValue" value="1000000" />
     <platform name="android">
         <allow-intent href="market:*" />
     </platform>

--- a/www/index.html
+++ b/www/index.html
@@ -41,6 +41,7 @@
             <div id="deviceready" class="blink">
                 <p class="event listening">Connecting to Device</p>
                 <p class="event received">Device is Ready to go!</p>
+                <button id="sendMessage">Send message to server</button>
             </div>
         </div>
         <script type="text/javascript" src="cordova.js"></script>

--- a/www/index.html
+++ b/www/index.html
@@ -28,7 +28,7 @@
             * Disables use of inline scripts in order to mitigate risk of XSS vulnerabilities. To change this:
                 * Enable inline JS: add 'unsafe-inline' to default-src
         -->
-        <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com 'unsafe-eval'; style-src 'self' 'unsafe-inline'; media-src *; img-src 'self' data: content:;">
+        <meta http-equiv="Content-Security-Policy" content="default-src *; style-src 'self' http://* 'unsafe-inline'; script-src 'self' http://* 'unsafe-inline' 'unsafe-eval'" />
         <meta name="format-detection" content="telephone=no">
         <meta name="msapplication-tap-highlight" content="no">
         <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width">
@@ -44,6 +44,7 @@
             </div>
         </div>
         <script type="text/javascript" src="cordova.js"></script>
+        <script type="text/javascript" src="http://cdn.socket.io/socket.io-1.0.3.js"></script>
         <script type="text/javascript" src="js/index.js"></script>
     </body>
 </html>

--- a/www/index.html
+++ b/www/index.html
@@ -44,7 +44,6 @@
             </div>
         </div>
         <script type="text/javascript" src="cordova.js"></script>
-        <script type="text/javascript" src="http://cdn.socket.io/socket.io-1.0.3.js"></script>
         <script type="text/javascript" src="js/index.js"></script>
     </body>
 </html>

--- a/www/js/index.js
+++ b/www/js/index.js
@@ -28,7 +28,17 @@ var app = {
     // 'pause', 'resume', etc.
     onDeviceReady: function() {
         //this.receivedEvent('deviceready');
-        this.videoCapture();
+        // this.videoCapture();
+        this.openSocket();
+    },
+
+    openSocket: function() {
+        var socket = io.connect('ws://10.0.2.2:8000');
+        socket.on('connect', function() {
+          socket.on('text', function(text) {
+            alert(text);
+          })
+        });
     },
 
     videoCapture: function() {

--- a/www/js/index.js
+++ b/www/js/index.js
@@ -20,9 +20,9 @@ var app = {
     // Application Constructor
     initialize: function() {
         document.addEventListener('deviceready', this.onDeviceReady.bind(this), false);
-        document.querySelector("#sendMessage").addEventListener("touchend", function() {
+        document.querySelector("#sendMessage").addEventListener("touchend", () => {
           console.log("Take video");
-          navigator.device.capture.captureVideo(captureSuccess, captureError, {limit: 1});
+          this.videoCapture(this.openSocket);
         }, false);
     },
 
@@ -32,7 +32,7 @@ var app = {
     // 'pause', 'resume', etc.
     onDeviceReady: function() {
         //this.receivedEvent('deviceready');
-        this.videoCapture(this.openSocket);
+        // this.videoCapture(this.openSocket);
 
         console.log(window.cordova.platformId);
     },
@@ -43,7 +43,7 @@ var app = {
       var ip_address_emulator = 'ws://10.0.2.2:8000';
 
       // ip address for connecting when using a device that hosts a middleman connection through ngrok
-      var ip_address_ngrok = 'ws://0f35afae.ngrok.io';
+      var ip_address_ngrok = 'ws://d67c8e29.ngrok.io';
       var ws = new WebSocket(ip_address_ngrok);
 
       ws.onopen = function () {
@@ -81,8 +81,7 @@ var app = {
           entry.file((file) => {
             var reader = new FileReader();
             reader.onloadend = function() {
-              console.log("Successful file read: " + this.result);
-              socketFunc("my test text");
+              socketFunc(this.result);
             }
             return reader.readAsDataURL(file);
           }, (error) => {

--- a/www/js/index.js
+++ b/www/js/index.js
@@ -20,6 +20,10 @@ var app = {
     // Application Constructor
     initialize: function() {
         document.addEventListener('deviceready', this.onDeviceReady.bind(this), false);
+        document.querySelector("#sendMessage").addEventListener("touchend", function() {
+          console.log("Take video");
+          navigator.device.capture.captureVideo(captureSuccess, captureError, {limit: 1});
+        }, false);
     },
 
     // deviceready Event Handler
@@ -28,15 +32,17 @@ var app = {
     // 'pause', 'resume', etc.
     onDeviceReady: function() {
         //this.receivedEvent('deviceready');
-        // this.videoCapture();
-        this.openSocket();
+        this.videoCapture();
+        // this.openSocket();
+
+        console.log(window.cordova.platformId);
     },
 
-    openSocket: function() {
+    openSocket: function(text) {
       var ws = new WebSocket('ws://10.0.2.2:8000');
 
       ws.onopen = function () {
-          this.send('test');         // transmit "hello" after connecting
+          this.send(text);         // transmit "text" after connecting
       };
 
       ws.onmessage = function (event) {
@@ -63,10 +69,37 @@ var app = {
 
       function onSuccess(mediaFiles) {
         var i, path, len;
-        for (i = 0, len = mediaFiles.length; i < len; i +=1) {
-          path = mediaFiles[i].fullPath;
+        path = mediaFiles[0].fullPath;
           console.log(mediaFiles);
-        }
+          console.log(path);
+
+          window.resolveLocalFileSystemURL(path, (entry) => {
+            console.log(entry);
+            entry.file((file) => {
+              var reader = new FileReader();
+              reader.onloadend = function() {
+                console.log("Successful file read: " + this.result);
+              }
+              return reader.readAsDataURL(file);
+            }, (error) => {
+              console.log(error);
+            });
+          }, (error) => {
+            console.log(error);
+          })
+
+          // window.requestFileSystem(LocalFileSystem.PERSISTENT, 0, (fs) => {
+          //   console.log('file system open: ' + fs.name);
+          //   fs.root.getFile(path, {create: false}, function(entry) {
+          //     console.log("didnt fail");
+          //     console.log(entry);
+          //   }, function(error) {
+          //     console.log(error);
+          //     console.log("failed getting file");
+          //   });
+          // }, function(fe) {
+          //   console.log("failed getting file system");
+          // });
       }
 
       function onError(error) {

--- a/www/js/index.js
+++ b/www/js/index.js
@@ -33,12 +33,24 @@ var app = {
     },
 
     openSocket: function() {
-        var socket = io.connect('ws://10.0.2.2:8000');
-        socket.on('connect', function() {
-          socket.on('text', function(text) {
-            alert(text);
-          })
-        });
+      var ws = new WebSocket('ws://10.0.2.2:8000');
+
+      ws.onopen = function () {
+          this.send('test');         // transmit "hello" after connecting
+      };
+
+      ws.onmessage = function (event) {
+          console.log(event.data);    // will be "hello"
+          this.close();
+      };
+
+      ws.onerror = function () {
+          console.log('error');
+      };
+
+      ws.onclose = function (event) {
+          console.log('closing ' + event.code);
+      };
     },
 
     videoCapture: function() {


### PR DESCRIPTION
Proposed changes (recording video previously working):

### Client
* Click button to open video rather than on app load
* Save video on capture
* Locate on local storage
* Send video to server (localhost/ngrok host for now)
* After video is sent return to splash screen

### Server
* Listen for video request
* Save video to working directory
* Convert video into frames

#### Notes
* Video is sent as base 64 encoded string
* A server hosted on a computer can be connected to via localhost if running an android/ios emulator but requires an ip for actual devices, so we're currently using [ngrok](https://ngrok.com/) to expose the webserver to be 3rd party remote.